### PR TITLE
Upgrade finite-typelits

### DIFF
--- a/acts.cabal
+++ b/acts.cabal
@@ -63,9 +63,9 @@ common common
         -DFIN
     build-depends:
         finitary
-          >= 1.2.0.0 && < 2.2
+          >= 1.2.0.0 && < 2.3
       , finite-typelits
-          >= 0.1.4.2 && < 0.1.7
+          >= 0.1.4.2 && < 0.2.2
 
   default-language:
       Haskell2010
@@ -91,8 +91,7 @@ library
       Data.Act
 
   build-depends:
-      deepseq
-        ^>= 1.4.4.0
+      deepseq >= 1.4.4.0 && < 1.6
 
 
 library acts-examples

--- a/src/Data/Act.hs
+++ b/src/Data/Act.hs
@@ -4,11 +4,13 @@
   , DeriveDataTypeable
   , DerivingVia
   , FlexibleInstances
+  , FlexibleContexts
   , GeneralizedNewtypeDeriving
   , MultiParamTypeClasses
   , ScopedTypeVariables
   , StandaloneDeriving
   , TypeFamilies
+  , TypeOperators
   , UndecidableInstances
 #-}
 


### PR DESCRIPTION
Newer finite-typelits package changed the exported type constructor `Finite` from actual data constructor to type alias, which has caused compile errors without FlexibleContexts.

This commit adds LANGUAGE pragmas for
- FlexibleContexts
- TypeOperators (to use `~` in newer GHC; see https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0371-non-magical-eq.md )

Also relaxes bounds for `finitary`, `finite-typelits`, and `deepseq`